### PR TITLE
fix instances ui problem

### DIFF
--- a/src/ui/src/Instances.py
+++ b/src/ui/src/Instances.py
@@ -241,11 +241,9 @@ class Instances:
                     env_variables = {env.name: env.value or "" for env in pod.spec.containers[0].env}
 
                     status = "up"
-                    if pod.status.conditions is not None:
-                        for condition in pod.status.conditions:
-                            if condition.type == "Ready" and condition.status == "True":
-                                status = "down"
-                                break
+                    if pod.status.phase != "Running":
+                        status = "down"
+                        break
 
                     instances.append(
                         Instance(


### PR DESCRIPTION
In a kubernetes environnement, when deploying the application following the documentation and while everything works fine in the cluster side, meaning that all pods are up, evrything works fine, etc... the instances in the bunerweb-ui appears down all the time. This is because of the condition that i removed, read it and you'll understand that status will always be down or it will be up when the pods are not up lol, i think it was just a typo mistake it should have been inversed, declare status = "down",  and status inside the if condition to be up or change the condition to be != instead of ==, etc..

I've added a better and simpler test to check the status of the pods. this fix also the problem of pods appearing in the bunkerweb-ui appearing always down (it's clear based on the old condition).

Regards